### PR TITLE
feat(database): add initial kanban schema with tracking and assignments

### DIFF
--- a/app/Models/Board.php
+++ b/app/Models/Board.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Board extends Model
+{
+    protected $fillable = [
+        'project_id',
+        'title'
+    ];
+}

--- a/app/Models/Column.php
+++ b/app/Models/Column.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Column extends Model
+{
+    protected $fillable = [
+        'board_id',
+        'title',
+        'order'
+    ];
+}

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Project extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'name',
+        'description'
+    ];
+}

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Task extends Model
+{
+    protected $fillable = [
+        'column_id',
+        'parent_id',
+        'created_by',
+        'assigned_by',
+        'title',
+        'description',
+        'order',
+        'is_completed'
+    ];
+    public function column()
+    {
+        return $this->belongsTo(Column::class);
+    }
+
+    public function parent()
+    {
+        return $this->belongsTo(Task::class, 'parent_id');
+    }
+
+    public function subtasks()
+    {
+        return $this->hasMany(Task::class, 'parent_id');
+    }
+
+    public function createdBy()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function assignedBy()
+    {
+        return $this->belongsTo(User::class, 'assigned_by');
+    }
+
+    public function assignees()
+    {
+        return $this->belongsToMany(User::class, 'task_user');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -50,4 +50,19 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function createdTasks()
+    {
+        return $this->hasMany(Task::class, 'created_by');
+    }
+
+    public function assignedTasks()
+    {
+        return $this->hasMany(Task::class, 'assigned_by');
+    }
+
+    public function tasks()
+    {
+        return $this->belongsToMany(Task::class, 'task_user');
+    }
 }

--- a/database/migrations/2025_09_17_123553_create_projects_table.php
+++ b/database/migrations/2025_09_17_123553_create_projects_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('projects', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('projects');
+    }
+};

--- a/database/migrations/2025_09_17_123641_create_boards_table.php
+++ b/database/migrations/2025_09_17_123641_create_boards_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('boards', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('project_id')->constrained()->onDelete('cascade');
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('boards');
+    }
+};

--- a/database/migrations/2025_09_17_123703_create_columns_table.php
+++ b/database/migrations/2025_09_17_123703_create_columns_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('columns', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('board_id')->constrained()->onDelete('cascade');
+            $table->string('title');
+            $table->integer('order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('columns');
+    }
+};

--- a/database/migrations/2025_09_17_123748_create_tasks_table.php
+++ b/database/migrations/2025_09_17_123748_create_tasks_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tasks', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('column_id')->constrained()->onDelete('cascade');
+            $table->foreignId('parent_id')->nullable()->constrained('tasks')->onDelete('cascade'); // subtask
+            $table->foreignId('created_by')->constrained('users')->onDelete('cascade'); // quem criou
+            $table->foreignId('assigned_by')->nullable()->constrained('users')->onDelete('set null'); // quem designou
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->integer('order')->default(0);
+            $table->boolean('is_completed')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tasks');
+    }
+};

--- a/database/migrations/2025_09_17_124930_create_task_user_table.php
+++ b/database/migrations/2025_09_17_124930_create_task_user_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('task_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('task_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('task_user');
+    }
+};


### PR DESCRIPTION
- Created migrations for projects, boards, columns, tasks and task_user (pivot table).
- Added relationships for recursive tasks (subtasks).
- Added tracking fields for created_by and assigned_by in tasks.
- Implemented many-to-many relation between tasks and users for assignees.
- Updated models (Project, Board, Column, Task, User) with proper relationships.